### PR TITLE
Exclude unrelated files from the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "PEM file format encoder/decoder.",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "xo && jest test.js",
     "test-ci": "xo && jest --coverage test.js"


### PR DESCRIPTION
Set package.json#files to exclude example.js, test.js, and other files.

Right now, the npm package contains the following unused files:

| Size | Name
| --- | ---
| 173 | .editorconfig
| 221 | .travis.yml
| 204 | example.js
| 451 | pubkey.pem
| 1506 | test.js

P.S. Good job on the library!